### PR TITLE
mod: increase dtv timer to 120 minutes

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -11,7 +11,7 @@ namespace Crpg.Module.Modes.Dtv;
 internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 {
     private const int RewardMultiplier = 2;
-    private const int MapDuration = 60 * 90;
+    private const int MapDuration = 60 * 120;
 
     private readonly CrpgRewardServer _rewardServer;
     private readonly CrpgDtvData _dtvData;


### PR DESCRIPTION
With increased wave count and difficulty, players are running out of time once again to complete DTV.