### PR TITLE
mod: reduce dtv ranged unit count

### DIFF
--- a/src/Module.Server/ModuleData/characters.xml
+++ b/src/Module.Server/ModuleData/characters.xml
@@ -1389,7 +1389,6 @@
         <equipment slot="Body" id="Item.crpg_northern_leather_vest_v2_h0" />
         <equipment slot="Leg" id="Item.crpg_hosen_2_v1_h0" />
         <equipment slot="Item0" id="Item.crpg_iron_hand_axe_h0" />
-        <equipment slot="Item1" id="Item.crpg_noyans_shield_v2_h0" />
       </EquipmentRoster>
       <EquipmentRoster>
         <equipment slot="Head" id="Item.crpg_vlandia_bandit_cape_a_v2_h0" />
@@ -1784,8 +1783,6 @@
         <equipment slot="Gloves" id="Item.crpg_guarded_armwraps_v2_h0" />
         <equipment slot="Leg" id="Item.crpg_steppe_leather_boots_v2_h0" />
         <equipment slot="Item0" id="Item.crpg_yellow_katana_v1_h0" />
-        <equipment slot="Item1" id="Item.crpg_rokusun_yumi_h0" />
-        <equipment slot="Item2" id="Item.crpg_range_arrows_v1_h0" />
       </EquipmentRoster>
     </Equipments>
   </NPCCharacter>
@@ -3081,14 +3078,14 @@
       <EquipmentRoster>
         <equipment slot="Head" id="Item.crpg_spiked_helmet_with_facemask_v2_h0" />
         <equipment slot="Cape" id="Item.crpg_lamellar_shoulders_v2_h0" />
-        <equipment slot="Body" id="Item.crpg_eastern_lamellar_armor_v3_h0" />
+        <equipment slot="Body" id="Item.crpg_leather_lamellar_armor_v2_h0" />
         <equipment slot="Gloves" id="Item.crpg_eastern_plated_leather_vambraces_v2_h0" />
         <equipment slot="Leg" id="Item.crpg_reinforced_suede_boots_v2_h0" />
         <equipment slot="Horse" id="Item.crpg_mount1_courser_14_v1_h0" />
         <equipment slot="HorseHarness" id="Item.crpg_steppe_fur_harness_v1_h0" />
-        <equipment slot="Item0" id="Item.crpg_noble_steppe_bow_h0" />
-        <equipment slot="Item1" id="Item.crpg_broad_head_arrows_h0" />
-        <equipment slot="Item2" id="Item.crpg_fine_steel_scimitar_h0" />
+        <equipment slot="Item0" id="Item.crpg_heavy_cavalry_lance_h0" />
+        <equipment slot="Item1" id="Item.crpg_decorated_steppe_shield_v2_h0" />
+        <equipment slot="Item2" id="Item.crpg_iron_saber_h0" />
       </EquipmentRoster>
       <EquipmentRoster>
         <equipment slot="Head" id="Item.crpg_jackolantern_h0" />

--- a/src/Module.Server/ModuleData/dtv_data.xml
+++ b/src/Module.Server/ModuleData/dtv_data.xml
@@ -78,16 +78,16 @@
 
   <Round reward="310">
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.6" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.4" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.4" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.6" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.7" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.3" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.5" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.7" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.3" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.5" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.5" />
       <Group classDivisionId="crpg_dtv_amazon_boss" />
     </Wave>
   </Round>
@@ -131,20 +131,20 @@
 
   <Round reward="450">
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.5" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.5" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.5" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.5" />
       <Group classDivisionId="crpg_dtv_legion_veles" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.5" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.5" />
       <Group classDivisionId="crpg_dtv_legion_veles" count="0.8" />
       <Group classDivisionId="crpg_dtv_legion_cavalry" count="0.5" />
       <Group classDivisionId="crpg_dtv_legion_boss" />
@@ -153,17 +153,17 @@
 
   <Round reward="500">
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.2" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.3" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.4" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.5" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.5" />
       <Group classDivisionId="crpg_dtv_aserai_camelry" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.4" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.5" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.5" />
       <Group classDivisionId="crpg_dtv_aserai_camelry" count="1.0" />
       <Group classDivisionId="crpg_dtv_aserai_boss" />
     </Wave>
@@ -171,18 +171,18 @@
 
   <Round reward="550">
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.6" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.4" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.5" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.6" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.5" />
       <Group classDivisionId="crpg_dtv_highland_warrior" count="0.5" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.4" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.8" />
-      <Group classDivisionId="crpg_dtv_highland_warrior" count="1.2" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.2" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.6" />
+      <Group classDivisionId="crpg_dtv_highland_warrior" count="1.3" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.3" />
       <Group classDivisionId="crpg_dtv_highland_boss" />
     </Wave>
   </Round>

--- a/src/Module.Server/ModuleData/dtv_data.xml
+++ b/src/Module.Server/ModuleData/dtv_data.xml
@@ -14,25 +14,25 @@
     </Wave>
   </Round>
 
-  <Round reward="120">
+  <Round reward="110">
     <Wave>
-      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.0" />
-      <Group classDivisionId="crpg_dtv_recruit_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.4" />
+      <Group classDivisionId="crpg_dtv_recruit_archer" count="0.6" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.0" />
-      <Group classDivisionId="crpg_dtv_recruit_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.4" />
+      <Group classDivisionId="crpg_dtv_recruit_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_recruit_cavalry" count="0.3" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.0" />
-      <Group classDivisionId="crpg_dtv_recruit_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_recruit_squire" count="1.4" />
+      <Group classDivisionId="crpg_dtv_recruit_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_recruit_cavalry" count="0.3" />
       <Group classDivisionId="crpg_dtv_recruit_boss" />
     </Wave>
   </Round>
 
-  <Round reward="170">
+  <Round reward="160">
     <Wave>
       <Group classDivisionId="crpg_dtv_looter" count="2.0" />
     </Wave>
@@ -45,7 +45,7 @@
     </Wave>
   </Round>
 
-  <Round reward="220">
+  <Round reward="210">
     <Wave>
       <Group classDivisionId="crpg_dtv_fancy_lad" count="1.7" />
     </Wave>
@@ -60,7 +60,7 @@
     </Wave>
   </Round>
 
-  <Round reward="270">
+  <Round reward="260">
     <Wave>
       <Group classDivisionId="crpg_dtv_viking_huscarl" count="0.8" />
       <Group classDivisionId="crpg_dtv_viking_raider" count="1.2" />
@@ -76,44 +76,44 @@
     </Wave>
   </Round>
 
-  <Round reward="320">
+  <Round reward="310">
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="1.0" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.0" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.6" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.4" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="1.0" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.0" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.7" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.3" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_amazon_archer" count="1.0" />
-      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.0" />
+      <Group classDivisionId="crpg_dtv_amazon_archer" count="0.7" />
+      <Group classDivisionId="crpg_dtv_amazon_warrior" count="1.3" />
       <Group classDivisionId="crpg_dtv_amazon_boss" />
     </Wave>
   </Round>
 
-  <Round reward="370">
+  <Round reward="350">
     <Wave>
-      <Group classDivisionId="crpg_dtv_english_billman" count="0.6" />
-      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.4" />
-      <Group classDivisionId="crpg_dtv_english_archer" count="0.8" />
+      <Group classDivisionId="crpg_dtv_english_billman" count="0.75" />
+      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.55" />
+      <Group classDivisionId="crpg_dtv_english_archer" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_english_billman" count="0.6" />
-      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.6" />
-      <Group classDivisionId="crpg_dtv_english_archer" count="0.8" />
-      <Group classDivisionId="crpg_dtv_english_knight" count="0.4" />
+      <Group classDivisionId="crpg_dtv_english_billman" count="0.75" />
+      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.65" />
+      <Group classDivisionId="crpg_dtv_english_archer" count="0.5" />
+      <Group classDivisionId="crpg_dtv_english_knight" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_english_billman" count="0.8" />
-      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.6" />
-      <Group classDivisionId="crpg_dtv_english_archer" count="1.0" />
-      <Group classDivisionId="crpg_dtv_english_knight" count="0.8" />
+      <Group classDivisionId="crpg_dtv_english_billman" count="1.0" />
+      <Group classDivisionId="crpg_dtv_english_manatarms" count="0.8" />
+      <Group classDivisionId="crpg_dtv_english_archer" count="0.5" />
+      <Group classDivisionId="crpg_dtv_english_knight" count="0.9" />
       <Group classDivisionId="crpg_dtv_english_boss" />
     </Wave>
   </Round>
 
-  <Round reward="420">
+  <Round reward="400">
     <Wave>
       <Group classDivisionId="crpg_dtv_samurai_warrior" count="1.0" />
       <Group classDivisionId="crpg_dtv_samurai_ashigaru" count="1.0" />
@@ -129,65 +129,65 @@
     </Wave>
   </Round>
 
-  <Round reward="470">
+  <Round reward="450">
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.0" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.0" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_legion_veles" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.0" />
+      <Group classDivisionId="crpg_dtv_legion_soldier" count="1.4" />
       <Group classDivisionId="crpg_dtv_legion_centurion" count="0.3" />
-      <Group classDivisionId="crpg_dtv_legion_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_legion_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_legion_veles" count="0.8" />
       <Group classDivisionId="crpg_dtv_legion_cavalry" count="0.5" />
       <Group classDivisionId="crpg_dtv_legion_boss" />
     </Wave>
   </Round>
 
-  <Round reward="520">
+  <Round reward="500">
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.0" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.8" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.2" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.0" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.4" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_aserai_camelry" count="0.5" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.0" />
-      <Group classDivisionId="crpg_dtv_aserai_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.4" />
+      <Group classDivisionId="crpg_dtv_aserai_archer" count="0.6" />
       <Group classDivisionId="crpg_dtv_aserai_camelry" count="1.0" />
       <Group classDivisionId="crpg_dtv_aserai_boss" />
     </Wave>
   </Round>
 
-  <Round reward="570">
+  <Round reward="550">
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="1.0" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.0" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.6" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.4" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="1.0" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.6" />
       <Group classDivisionId="crpg_dtv_highland_warrior" count="0.5" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.0" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.4" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_highland_ranger" count="1.0" />
-      <Group classDivisionId="crpg_dtv_highland_warrior" count="1.0" />
-      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.0" />
+      <Group classDivisionId="crpg_dtv_highland_ranger" count="0.8" />
+      <Group classDivisionId="crpg_dtv_highland_warrior" count="1.2" />
+      <Group classDivisionId="crpg_dtv_highland_soldier" count="1.2" />
       <Group classDivisionId="crpg_dtv_highland_boss" />
     </Wave>
   </Round>
 
-  <Round reward="620">
+  <Round reward="600">
     <Wave>
       <Group classDivisionId="crpg_dtv_khuzait_soldier" count="1.5" />
       <Group classDivisionId="crpg_dtv_khuzait_horseman" count="0.5" />
@@ -203,29 +203,29 @@
     </Wave>
   </Round>
 
-  <Round reward="670">
+  <Round reward="650">
+    <Wave>
+      <Group classDivisionId="crpg_dtv_dwarven_engineer" count="0.8" />
+      <Group classDivisionId="crpg_dtv_dwarven_axelord" count="0.7" />
+      <Group classDivisionId="crpg_dtv_dwarven_hammerlord" count="0.7" />
+    </Wave>
     <Wave>
       <Group classDivisionId="crpg_dtv_dwarven_engineer" count="1.0" />
-      <Group classDivisionId="crpg_dtv_dwarven_axelord" count="0.6" />
-      <Group classDivisionId="crpg_dtv_dwarven_hammerlord" count="0.6" />
-    </Wave>
-    <Wave>
-      <Group classDivisionId="crpg_dtv_dwarven_engineer" count="1.5" />
-      <Group classDivisionId="crpg_dtv_dwarven_axelord" count="0.75" />
-      <Group classDivisionId="crpg_dtv_dwarven_hammerlord" count="0.75" />
-    </Wave>
-    <Wave>
-      <Group classDivisionId="crpg_dtv_dwarven_engineer" count="1.5" />
       <Group classDivisionId="crpg_dtv_dwarven_axelord" count="1.0" />
       <Group classDivisionId="crpg_dtv_dwarven_hammerlord" count="1.0" />
+    </Wave>
+    <Wave>
+      <Group classDivisionId="crpg_dtv_dwarven_engineer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_dwarven_axelord" count="1.25" />
+      <Group classDivisionId="crpg_dtv_dwarven_hammerlord" count="1.25" />
       <Group classDivisionId="crpg_dtv_dwarven_boss" />
     </Wave>
   </Round>
 
-  <Round reward="720">
+  <Round reward="700">
     <Wave>
-      <Group classDivisionId="crpg_dtv_tincan_soldier" count="1.5" />
-      <Group classDivisionId="crpg_dtv_tincan_archer" count="1.0" />
+      <Group classDivisionId="crpg_dtv_tincan_soldier" count="1.7" />
+      <Group classDivisionId="crpg_dtv_tincan_archer" count="0.8" />
     </Wave>
     <Wave>
       <Group classDivisionId="crpg_dtv_tincan_soldier" count="2.0" />
@@ -240,7 +240,7 @@
     </Wave>
   </Round>
 
-  <Round reward="770">
+  <Round reward="800">
     <Wave>
       <Group classDivisionId="crpg_dtv_halloween_soldier" count="1.5" />
       <Group classDivisionId="crpg_dtv_halloween_monster" count="1.5" />


### PR DESCRIPTION
- Reduced count of ranged units across most waves
- Replaced missing ranged units with melee
- Tweaked rewards