### PR TITLE
mod: fix dtv timer expiry reward

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -21,6 +21,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private int _currentWave;
     private bool _gameStarted;
     private bool _waveStarted;
+    private bool _timerExpired;
     private MissionTimer? _waveStartTimer;
     private MissionTimer? _endGameTimer;
     private MissionTime _currentRoundStartTime;
@@ -31,6 +32,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _dtvData = ReadDtvData();
         _gameStarted = false;
         _currentRound = -1;
+        _timerExpired = false;
     }
 
     public override bool IsGameModeHidingAllAgentVisuals => true;
@@ -53,6 +55,18 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     {
         base.AfterStart();
         AddTeams();
+    }
+
+    public override void OnBehaviorInitialize()
+    {
+        base.OnBehaviorInitialize();
+        MissionLobbyComponent.CurrentMultiplayerStateChanged += RewardIfEndOfMission;
+    }
+
+    public override void OnRemoveBehavior()
+    {
+        base.OnRemoveBehavior();
+        MissionLobbyComponent.CurrentMultiplayerStateChanged -= RewardIfEndOfMission;
     }
 
     public override bool CheckForWarmupEnd()
@@ -84,16 +98,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         if (MissionLobbyComponent.CurrentMultiplayerState != MissionLobbyComponent.MultiplayerGameState.Playing
             || !CanGameModeSystemsTickThisFrame)
         {
-            if (_gameStarted && TimerComponent.CheckIfTimerPassed()) // Reward players if timer expires
-            {
-                float roundDuration = _currentRoundStartTime.ElapsedSeconds;
-                _ = _rewardServer.UpdateCrpgUsersAsync(
-                durationRewarded: ComputeRoundReward(CurrentRoundData, wavesWon: Math.Max(_currentWave, 0)),
-                durationUpkeep: roundDuration,
-                updateUserStats: false,
-                constantMultiplier: RewardMultiplier);
-            }
-
             return;
         }
 
@@ -125,6 +129,20 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         {
             _waveStartTimer = null;
             StartNextWave();
+        }
+    }
+
+    public void RewardIfEndOfMission(MissionLobbyComponent.MultiplayerGameState newState)
+    {
+        if (!_timerExpired && TimerComponent.CheckIfTimerPassed() && newState == MissionLobbyComponent.MultiplayerGameState.Ending) // Award players if timer expires
+        {
+            _timerExpired = true;
+            float roundDuration = _currentRoundStartTime.ElapsedSeconds;
+            _ = _rewardServer.UpdateCrpgUsersAsync(
+                durationRewarded: ComputeRoundReward(CurrentRoundData, wavesWon: Math.Max(_currentWave, 0)),
+                durationUpkeep: roundDuration,
+                updateUserStats: false,
+                constantMultiplier: RewardMultiplier);
         }
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -21,6 +21,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private int _currentWave;
     private bool _gameStarted;
     private bool _waveStarted;
+    private bool _timerExpired;
     private MissionTimer? _waveStartTimer;
     private MissionTimer? _endGameTimer;
     private MissionTime _currentRoundStartTime;
@@ -31,6 +32,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _dtvData = ReadDtvData();
         _gameStarted = false;
         _currentRound = -1;
+        _timerExpired = false;
     }
 
     public override bool IsGameModeHidingAllAgentVisuals => true;
@@ -80,6 +82,17 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 
     public override void OnMissionTick(float dt)
     {
+        if (!_timerExpired && TimerComponent.CheckIfTimerPassed() && _gameStarted) // Award players if timer expires
+        {
+            _timerExpired = true;
+            float roundDuration = _currentRoundStartTime.ElapsedSeconds;
+            _ = _rewardServer.UpdateCrpgUsersAsync(
+            durationRewarded: ComputeRoundReward(CurrentRoundData, wavesWon: Math.Max(_currentWave, 0)),
+            durationUpkeep: roundDuration,
+            updateUserStats: false,
+            constantMultiplier: RewardMultiplier);
+        }
+
         base.OnMissionTick(dt);
         if (MissionLobbyComponent.CurrentMultiplayerState != MissionLobbyComponent.MultiplayerGameState.Playing
             || !CanGameModeSystemsTickThisFrame)

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -21,7 +21,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private int _currentWave;
     private bool _gameStarted;
     private bool _waveStarted;
-    private bool _timerExpired;
     private MissionTimer? _waveStartTimer;
     private MissionTimer? _endGameTimer;
     private MissionTime _currentRoundStartTime;
@@ -32,7 +31,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _dtvData = ReadDtvData();
         _gameStarted = false;
         _currentRound = -1;
-        _timerExpired = false;
     }
 
     public override bool IsGameModeHidingAllAgentVisuals => true;
@@ -82,21 +80,20 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 
     public override void OnMissionTick(float dt)
     {
-        if (!_timerExpired && TimerComponent.CheckIfTimerPassed() && _gameStarted) // Award players if timer expires
-        {
-            _timerExpired = true;
-            float roundDuration = _currentRoundStartTime.ElapsedSeconds;
-            _ = _rewardServer.UpdateCrpgUsersAsync(
-            durationRewarded: ComputeRoundReward(CurrentRoundData, wavesWon: Math.Max(_currentWave, 0)),
-            durationUpkeep: roundDuration,
-            updateUserStats: false,
-            constantMultiplier: RewardMultiplier);
-        }
-
         base.OnMissionTick(dt);
         if (MissionLobbyComponent.CurrentMultiplayerState != MissionLobbyComponent.MultiplayerGameState.Playing
             || !CanGameModeSystemsTickThisFrame)
         {
+            if (_gameStarted && TimerComponent.CheckIfTimerPassed()) // Reward players if timer expires
+            {
+                float roundDuration = _currentRoundStartTime.ElapsedSeconds;
+                _ = _rewardServer.UpdateCrpgUsersAsync(
+                durationRewarded: ComputeRoundReward(CurrentRoundData, wavesWon: Math.Max(_currentWave, 0)),
+                durationUpkeep: roundDuration,
+                updateUserStats: false,
+                constantMultiplier: RewardMultiplier);
+            }
+
             return;
         }
 


### PR DESCRIPTION
Checks whether the `TimerComponent` has finished after the game has started. Then awards players if the timer expires.

As the `MissionLobbyComponent` also conducts a similar check to end the match, the reward check is executed at the start of `OnMissionTick()`