### PR TITLE
mod: Apply glove armor to punch damage

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -54,15 +54,14 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
         if (weapon.IsEmpty)
         {
             // Increase fist damage with strength and glove armor.
-            // Alternate attack if is weapon empty is a kick.
             int strengthSkill = GetSkillValue(attackInformation.AttackerAgentOrigin, CrpgSkills.Strength);
             int glovearmor = GetGloveArmor(attackInformation.AttackerAgentOrigin);
-            if (collisionData.IsAlternativeAttack)
+            if (collisionData.IsAlternativeAttack) //Kick
             {
-                return (finalDamage * 0.75f) * (1 + 0.02f * strengthSkill);
+                return finalDamage * 0.75f * (1 + 0.02f * strengthSkill);
             }
 
-            return (finalDamage * 0.75f) * (1 + (0.02f * strengthSkill) + (0.04f * glovearmor));
+            return finalDamage * 0.75f * (1 + 0.02f * strengthSkill + 0.04f * glovearmor);
         }
 
         // CalculateShieldDamage only has dmg as parameter. Therefore it cannot be used to get any Skill values.

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -1,4 +1,5 @@
-﻿using Crpg.Module.Helpers;
+﻿using System.Diagnostics.Eventing.Reader;
+using Crpg.Module.Helpers;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -52,9 +53,16 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
 
         if (weapon.IsEmpty)
         {
-            // Increase fist damage with strength.
+            // Increase fist damage with strength and glove armor.
+            // Alternate attack if is weapon empty is a kick.
             int strengthSkill = GetSkillValue(attackInformation.AttackerAgentOrigin, CrpgSkills.Strength);
-            return finalDamage * (1 + 0.03f * strengthSkill);
+            int glovearmor = GetGloveArmor(attackInformation.AttackerAgentOrigin);
+            if (collisionData.IsAlternativeAttack)
+            {
+                return (finalDamage * 0.75f) * (1 + 0.02f * strengthSkill);
+            }
+
+            return (finalDamage * 0.75f) * (1 + (0.02f * strengthSkill) + (0.04f * glovearmor));
         }
 
         // CalculateShieldDamage only has dmg as parameter. Therefore it cannot be used to get any Skill values.
@@ -269,5 +277,15 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
         }
 
         return false;
+    }
+
+    private int GetGloveArmor(IAgentOriginBase agentOrigin)
+    {
+        if (agentOrigin is CrpgBattleAgentOrigin crpgOrigin)
+        {
+            return crpgOrigin.ArmorItems.FirstOrDefault(a => a.type == ItemObject.ItemTypeEnum.HandArmor).armor?.ArmArmor ?? 0;
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
Reduced base punch damage and str based bonus, added glove armor based bonus
Kick uses str bonus, so kick = bare hand punch

_**Old System**_
**48str**
 - Vs unarmored, 10 body damage, 12 head
 - Vs medium, 7 damage body, 10 head
 - Vs Heavy, 7 bodyy, 7 head
 
 **15str**
 - Vs unarmored, 6 body damage, 7 head
 - Vs medium, 4 damage body, 6 head
 - Vs Heavy, 4 body, 4 head

_**New System**_
 **15str, 33gloves (no gloves)**
 - Vs unarmored, 8(5) body damage, 12(6) head
 - Vs medium, 6(3) damage body, 8(4) head
 - Vs Heavy, 6(3) body, 8(4) head

 **48str, 33gloves (no gloves)**
 - Vs unarmored, 10(6) body damage, 15(7) head
 - Vs medium, 7(4) damage body, 10(6) head
 - Vs Heavy, 7(4) body, 10(4) head

 **30str, 33gloves (no gloves)**
 - Vs unarmored, 9(5) body damage, 11(6) head
 - Vs medium, 7(4) damage body, 9(5) head
 - Vs Heavy, 7(4) body, 9(4) head

(Note, test while attacker and defender stationary)