### PR TITLE
mod: increase bark limit slightly to 5

### DIFF
--- a/src/Module.Client/GUI/CrpgMissionGauntletMainAgentCheerControllerView.cs
+++ b/src/Module.Client/GUI/CrpgMissionGauntletMainAgentCheerControllerView.cs
@@ -327,7 +327,7 @@ public class CrpgMissionGauntletMainAgentCheerControllerView : MissionView
 
     private void ResetBarkUses()
     {
-        _barkUsesLeft = 3;
+        _barkUsesLeft = 5;
         _barkUsesResetCooldownTime = 60;
     }
 


### PR DESCRIPTION
Increase bark limit to 5 for improved communication

The previous limit was found to be restrictive during tests conducted on the beta server, possibly harming communicating in-game, a limit of 5 offers enough ability to communicate without being too spammy.