### PR TITLE
Update cRPG Discord Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ PRs or PRs with no context might get ignored.
 
 ## Add a feature / Fix a bug
 
-- Discuss first with the developers on the [cRPG Discord](https://discord.gg/c-rpg) if
+- Discuss first with the developers on the [cRPG Discord]([https://discord.gg/c-rpg](https://discord.gg/crpg-279063743839862805)) if
   you're adding a new feature
 - Open a new GitHub pull request with the patch
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ that adds persistence (xp, gold, items, stats) to the multiplayer.
 We encourage you to contribute to cRPG! Please check out the [Contributing guide](https://github.com/verdie-g/crpg/blob/master/CONTRIBUTING.md)
 for guidelines about how to proceed.
 
-If you just have a question, you can ask it on the [cRPG Discord](https://discord.gg/c-rpg).
+If you just have a question, you can ask it on the [cRPG Discord](https://discord.gg/crpg-279063743839862805).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Reporting a Vulnerability
 
-Contact a @Mod Developer on [Discord](https://discord.gg/c-rpg) or send an
+Contact a @Mod Developer on [Discord](https://discord.gg/crpg-279063743839862805) or send an
 email to [hello@c-rpg.eu](mailto:hello@c-rpg.eu).

--- a/src/WebUI/src/components/app/ErrorBoundary.vue
+++ b/src/WebUI/src/components/app/ErrorBoundary.vue
@@ -42,7 +42,7 @@ const goToRootPage = () => {
               <template #discordLink>
                 <a
                   class="text-content-link hover:text-content-link-hover"
-                  href="https://discord.gg/c-rpg"
+                  href="https://discord.gg/crpg-279063743839862805"
                   target="_blank"
                 >
                   Discord

--- a/src/WebUI/src/components/app/Socials.vue
+++ b/src/WebUI/src/components/app/Socials.vue
@@ -22,7 +22,7 @@ const socialsLinks: SocialLink[] = [
     id: 'discord',
     title: 'Discord',
     icon: 'discord',
-    href: 'https://discord.gg/c-rpg',
+    href: 'https://discord.gg/crpg-279063743839862805',
   },
   {
     id: 'reddit',

--- a/src/WebUI/src/components/user/UserRestrictionGuide.vue
+++ b/src/WebUI/src/components/user/UserRestrictionGuide.vue
@@ -15,7 +15,7 @@
             <a
               class="text-content-link hover:text-content-link-hover"
               target="_blank"
-              href="https://discord.gg/c-rpg"
+              href="https://discord.gg/crpg-279063743839862805"
             >
               Discord
             </a>


### PR DESCRIPTION
Updating cRPG Discord link on the website to a generic link as opposed to vanity URL - We lost level 3 boost on Discord hence why this change is being made.

Change ensures that even if vanity URL expires (regardless of whether we get it back or not) this will not affect cRPG platform in any way.