### PR TITLE
mod: fix DTV bot count calculation

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -79,12 +79,22 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     public override void OnPeerChangedTeam(NetworkCommunicator networkPeer, Team oldTeam, Team newTeam)
     {
         var missionPeer = networkPeer.GetComponent<MissionPeer>();
-        if (missionPeer == null || newTeam == Mission.SpectatorTeam)
+        var crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+        if (missionPeer == null)
         {
             return;
         }
 
-        missionPeer.Team = Mission.DefenderTeam;
+        if (newTeam != Mission.SpectatorTeam)
+        {
+            missionPeer.Team = Mission.DefenderTeam;
+            return;
+        }
+
+        if (crpgPeer != null)
+        {
+            crpgPeer.LastSpawnInfo = null;
+        }
     }
 
     public override void OnAgentBuild(Agent agent, Banner banner)

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml.Serialization;
+using Crpg.Module.Common;
 using Crpg.Module.Rewards;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -308,11 +309,9 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         int defendersCount = 0;
         foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
         {
-            var missionPeer = networkPeer.GetComponent<MissionPeer>();
+            var crpgPeer = networkPeer.GetComponent<CrpgPeer>();
             if (!networkPeer.IsSynchronized
-                || missionPeer == null
-                || missionPeer.Team == null
-                || missionPeer.Team.Side == BattleSideEnum.None)
+                || crpgPeer.LastSpawnInfo == null)
             {
                 continue;
             }


### PR DESCRIPTION
People were exploiting spawning in before wave 1 of a round would start. When you spawn in you would be eligible to get rewards, but when you go back to spec before wave 1 starts the bot count would not increase because bot count per player would only get increased if players were in the team on starting Wave 1.