### PR TITLE
mod: hide current map from voting screen

### DIFF
--- a/src/Module.Client/GUI/Intermission/CrpgIntermissionVM.cs
+++ b/src/Module.Client/GUI/Intermission/CrpgIntermissionVM.cs
@@ -655,6 +655,11 @@ public class CrpgIntermissionVM : ViewModel
                 IsMapVoteEnabled = true;
                 foreach (IntermissionVoteItem mapItem in mapVoteItems)
                 {
+                    if (mapItem.Id == Mission.Current.SceneName)
+                    {
+                        continue;
+                    }
+
                     if (AvailableMaps.FirstOrDefault((MPIntermissionMapItemVM m) => m.MapID == mapItem.Id) == null)
                     {
                         AvailableMaps.Add(new MPIntermissionMapItemVM(mapItem.Id, OnPlayerVotedForMap));
@@ -825,4 +830,3 @@ public class CrpgIntermissionVM : ViewModel
         _votedCultureItem.Votes++;
     }
 }
-


### PR DESCRIPTION
Hides current map from the client during voting.

`MapPoolComponent.cs` casts a single vote `OnMissionEnd()`. This may impact the winning map if only one vote is cast by players.