### PR TITLE
mod: cleanup dtv horses

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -27,7 +27,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private bool _timerExpired;
     private MissionTimer? _waveStartTimer;
     private MissionTimer? _endGameTimer;
-    private MissionTime _currentWaveStartTime;
     private MissionTime _currentRoundStartTime;
 
     public CrpgDtvServer(CrpgRewardServer rewardServer)
@@ -253,7 +252,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _currentRoundDefendersCount = _currentWave == 0 ? GetDefendersCount() : _currentRoundDefendersCount;
         SpawningBehavior.RequestSpawnSessionForWaveStart(CurrentWaveData, _currentRoundDefendersCount);
         SendDataToPeers(new CrpgDtvWaveStartMessage { Wave = _currentWave });
-        _currentWaveStartTime = MissionTime.Now;
         _waveStarted = true;
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -346,6 +346,21 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
             return false;
         }
 
+        float numberOfCavalry = 0;
+
+        foreach (Agent agent in Mission.AttackerTeam.ActiveAgents)
+        {
+            if (agent.HasMount)
+            {
+                numberOfCavalry++;
+            }
+        }
+
+        if (numberOfCavalry / SpawningBehavior.SpawnedAttackers <= 0.75f)
+        {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
@@ -138,8 +138,6 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
             SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
             SpawnedAttackers++;
         }
-
-        Debug.Print($"Spawned a total of {SpawnedAttackers} attacker(s)!");
     }
 
     private float ComputeScaledGroupCount(CrpgDtvGroup group, int defendersCount)

--- a/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
@@ -15,8 +15,6 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
 
     private MissionTimer? _defendersSpawnWindowTimer;
 
-    public int SpawnedAttackers { get; private set; } = 0;
-
     public CrpgDtvSpawningBehavior(CrpgConstants constants)
         : base(constants)
     {
@@ -108,7 +106,6 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
 
     private void SpawnAttackers(CrpgDtvWave wave, int defendersCount)
     {
-        SpawnedAttackers = 0;
         float expectedWaveBotsCount = wave.Groups.Sum(g => ComputeScaledGroupCount(g, defendersCount));
         // Round up number if it's like 3.999
         expectedWaveBotsCount = expectedWaveBotsCount - Math.Truncate(expectedWaveBotsCount) > 0.99
@@ -124,7 +121,6 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
             for (int i = 0; i < groupBotCount; i++)
             {
                 SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
-                SpawnedAttackers++;
             }
         }
 
@@ -136,7 +132,6 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
         {
             var group = groupsWithoutBoss[i % groupsWithoutBoss.Length];
             SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
-            SpawnedAttackers++;
         }
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
@@ -15,6 +15,8 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
 
     private MissionTimer? _defendersSpawnWindowTimer;
 
+    public int SpawnedAttackers { get; private set; } = 0;
+
     public CrpgDtvSpawningBehavior(CrpgConstants constants)
         : base(constants)
     {
@@ -106,6 +108,7 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
 
     private void SpawnAttackers(CrpgDtvWave wave, int defendersCount)
     {
+        SpawnedAttackers = 0;
         float expectedWaveBotsCount = wave.Groups.Sum(g => ComputeScaledGroupCount(g, defendersCount));
         // Round up number if it's like 3.999
         expectedWaveBotsCount = expectedWaveBotsCount - Math.Truncate(expectedWaveBotsCount) > 0.99
@@ -121,6 +124,7 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
             for (int i = 0; i < groupBotCount; i++)
             {
                 SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+                SpawnedAttackers++;
             }
         }
 
@@ -132,7 +136,10 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
         {
             var group = groupsWithoutBoss[i % groupsWithoutBoss.Length];
             SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+            SpawnedAttackers++;
         }
+
+        Debug.Print($"Spawned a total of {SpawnedAttackers} attacker(s)!");
     }
 
     private float ComputeScaledGroupCount(CrpgDtvGroup group, int defendersCount)


### PR DESCRIPTION
Cleans up mounts at the end of a DTV round to prevent them getting stuck on flee-lines.

1. Round ends.
2. Kill all tagged mounts without a rider.
3. Remove tags from all remaining mounts (because they have a rider).
4. Tag all `MountsWithoutRiders`, and force them to panic.