### PR TITLE
mod: enable conquest attacker/defender icons

### DIFF
--- a/src/Module.Client/GUI/Scoreboard/CrpgScoreboardSideVM.cs
+++ b/src/Module.Client/GUI/Scoreboard/CrpgScoreboardSideVM.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Crpg.Module.GUI.HudExtension;
 using Crpg.Module.GUI.Scoreboard;
+using Crpg.Module.Modes.Conquest;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
@@ -89,7 +90,7 @@ public class CrpgScoreboardSideVM : ViewModel
         IsSecondSide = isSecondSide;
         CultureId = text;
         TeamColor = "0x" + @object.Color2.ToString("X");
-        ShowAttackerOrDefenderIcons = Mission.Current.HasMissionBehavior<MissionMultiplayerSiegeClient>();
+        ShowAttackerOrDefenderIcons = Mission.Current.HasMissionBehavior<CrpgConquestClient>();
         IsAttacker = missionScoreboardSide.Side == BattleSideEnum.Attacker;
         RefreshValues();
         NetworkCommunicator.OnPeerAveragePingUpdated += OnPeerPingUpdated;

--- a/src/Module.Client/GUI/TeamSelection/CrpgTeamSelectInstanceVM.cs
+++ b/src/Module.Client/GUI/TeamSelection/CrpgTeamSelectInstanceVM.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Crpg.Module.GUI.HudExtension;
+using Crpg.Module.Modes.Conquest;
 using JetBrains.Annotations;
 using TaleWorlds.Core;
 using TaleWorlds.Core.ViewModelCollection.Information;
@@ -20,7 +21,7 @@ namespace TaleWorlds.MountAndBlade.ViewModelCollection.Multiplayer.TeamSelection
             _onSelect = onSelect;
             _culture = culture;
             Mission mission = Mission.Current;
-            IsSiege = mission != null && mission.HasMissionBehavior<MissionMultiplayerSiegeClient>();
+            IsSiege = mission != null && mission.HasMissionBehavior<CrpgConquestClient>();
             if (Team != null && Team.Side != BattleSideEnum.None)
             {
                 _missionScoreboardComponent = missionScoreboardComponent;


### PR DESCRIPTION
Adds attacker & defender icons to scoreboard and team selection pages

![image](https://github.com/namidaka/crpg/assets/93069911/aff5ffaf-72b3-429c-b10a-1d60d5c9532b)

![image](https://github.com/namidaka/crpg/assets/93069911/a9c051a0-7252-40aa-9820-75ff6083822f)
