### PR TITLE
mod: fix map sprite data crash

### DIFF
--- a/src/Module.Client/GUI/MapSpriteData.xml
+++ b/src/Module.Client/GUI/MapSpriteData.xml
@@ -1253,6 +1253,7 @@
       <SheetX>0</SheetX>
       <SheetY>0</SheetY>
       <CategoryName>ui_mploading</CategoryName>
+    </SpritePart>
     <SpritePart>
       <SheetID>137</SheetID>
       <Name>crpg_conquest_volskulkeep</Name>
@@ -1261,7 +1262,6 @@
       <SheetX>0</SheetX>
       <SheetY>0</SheetY>
       <CategoryName>ui_mploading</CategoryName>
-    </SpritePart>
     </SpritePart>
   </SpriteParts>
   <Sprites>


### PR DESCRIPTION
Misplaced `</SpritePart>` tag causes client crash on startup caused by d849e1c