### PR TITLE
mod: fix commander ui

### DIFF
--- a/src/Module.Client/GUI/Prefabs/MultiplayerScoreboardSideTop.xml
+++ b/src/Module.Client/GUI/Prefabs/MultiplayerScoreboardSideTop.xml
@@ -56,7 +56,7 @@
             </ListPanel>
 
             <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPScoreboard.TitleText" HorizontalAlignment="!PlayerCountTextAlignment" Text="@PlayersText"/>
-            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPScoreboard.TitleText" HorizontalAlignment="!PlayerCountTextAlignment" Text="@ Text" IsVisible="@ShowCommanders"/>
+            <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" Brush="MPScoreboard.TitleText" HorizontalAlignment="!PlayerCountTextAlignment" Text="@CommanderText" IsVisible="@ShowCommanders"/>
           </Children>
         </ListPanel>
 

--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -30,7 +30,6 @@
     <Compile Remove="..\Module.Server\Rating\**" />
     <Compile Remove="..\Module.Server\Api\*Client.cs" />
     <Compile Remove="..\Module.Server\Common\Commander\CommanderBehaviorServer.cs" />
-    <Compile Remove="..\Module.Server\Common\Commander\CommanderUpdateRequest.cs" />
     <Compile Remove="..\Module.Server\Modes\Battle\CrpgBattleServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Conquest\CrpgConquestServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Duel\CrpgDuelServer.cs" />


### PR DESCRIPTION
- Fixes typo in GauntletUI, preventing current Commanders being displayed on scoreboard.
- Removes unnecessary csproj object