### PR TITLE
mod: remove map voting screen

### DIFF
--- a/src/Module.Client/GUI/Intermission/CrpgIntermissionVM.cs
+++ b/src/Module.Client/GUI/Intermission/CrpgIntermissionVM.cs
@@ -18,6 +18,7 @@ public class CrpgIntermissionVM : ViewModel
     private MultiplayerIntermissionState _currentIntermissionState = default!;
 
     private readonly TextObject _voteLabelText = new TextObject("{=KOVHgkVq}Voting Ends In:");
+    private readonly TextObject _waitLabelText = new TextObject("{=OZYLgnQq}Please Wait:");
 
     private readonly TextObject _nextGameLabelText = new TextObject("{=lX9Qx7Wo}Next Game Starts In:");
 
@@ -641,7 +642,7 @@ public class CrpgIntermissionVM : ViewModel
         if (_currentIntermissionState == MultiplayerIntermissionState.CountingForMapVote)
         {
             int num = (int)_baseNetworkComponent.CurrentIntermissionTimer;
-            NextGameStateTimerLabel = _voteLabelText.ToString();
+            NextGameStateTimerLabel = _waitLabelText.ToString();
             NextGameStateTimerValue = num.ToString();
             IsMissionTimerEnabled = true;
             IsEndGameTimerEnabled = false;
@@ -649,26 +650,6 @@ public class CrpgIntermissionVM : ViewModel
             IsCultureVoteEnabled = false;
             IsPlayerCountEnabled = true;
             flag = false;
-            List<IntermissionVoteItem> mapVoteItems = MultiplayerIntermissionVotingManager.Instance.MapVoteItems;
-            if (mapVoteItems.Count > 0)
-            {
-                IsMapVoteEnabled = true;
-                foreach (IntermissionVoteItem mapItem in mapVoteItems)
-                {
-                    if (mapItem.Id == Mission.Current.SceneName)
-                    {
-                        continue;
-                    }
-
-                    if (AvailableMaps.FirstOrDefault((MPIntermissionMapItemVM m) => m.MapID == mapItem.Id) == null)
-                    {
-                        AvailableMaps.Add(new MPIntermissionMapItemVM(mapItem.Id, OnPlayerVotedForMap));
-                    }
-
-                    int voteCount = mapItem.VoteCount;
-                    AvailableMaps.First((MPIntermissionMapItemVM m) => m.MapID == mapItem.Id).Votes = voteCount;
-                }
-            }
         }
 
         if (_baseNetworkComponent.ClientIntermissionState == MultiplayerIntermissionState.CountingForCultureVote)

--- a/src/Module.Client/GUI/Prefabs/CrpgIntermission.xml
+++ b/src/Module.Client/GUI/Prefabs/CrpgIntermission.xml
@@ -21,7 +21,6 @@
         </Widget>
 
         <!-- Top Panel -->
-        <!-- 
           <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="180" MarginLeft="30" MarginRight="30" MarginTop="30">
             <Children>
               
@@ -37,10 +36,9 @@
                   <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Label.Text" Text="@NextGameStateTimerLabel" />
                   <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Center" Brush="MPIntermission.Value.Text" Brush.FontSize="50" Text="@NextGameStateTimerValue" />
                 </Children>
-              </ListPanel>-->
+              </ListPanel>
 
         <!-- Leave Button -->
-        <!-- 
               <NavigationScopeTargeter ScopeID="LeaveButtonScope" ScopeParent="..\LeaveButtonParent" />
               <ListPanel Id="LeaveButtonParent" WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren" HorizontalAlignment="Right" VerticalAlignment="Top" StackLayout.LayoutMethod="VerticalBottomToTop">
                 <Children>
@@ -50,7 +48,7 @@
               </ListPanel>
           
             </Children>
-          </Widget> -->
+          </Widget>
 
         <!-- Banners -->
         <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren" VerticalAlignment="Top" HorizontalAlignment="Center" PositionYOffset="210" MarginLeft="18" MarginRight="18">

--- a/src/Module.Server/ModuleData/Languages/CNs/std_native_strings_xml-zho-CN.xml
+++ b/src/Module.Server/ModuleData/Languages/CNs/std_native_strings_xml-zho-CN.xml
@@ -25,6 +25,10 @@
     <string id="OUnhyvby" text="保卫子爵" />
     <string id="bp8JJZpG" text="·   保卫子爵免受敌人的攻击！{newline}·   保护子爵会获得奖励！{newline}·   在 c-rpg.eu 上升级你的角色。" />
     <string id="3uoZAXxh" text="保卫子爵" />
+    
+    <!-- Intermission -->
+    <string id="OZYLgnQq" text="请稍候：" />
+    
     <string id="fBDiQBrC" text="生活" />
     <string id="gaC79g3U" text="你的角色身高有点奇怪。在 Bannerlord Armory 中修复它以加入 cRPG 服务器。" />
     <string id="qoYQE5yX" text="你已被 cRPG 服务器封禁。" />

--- a/src/Module.Server/ModuleData/Languages/RU/std_native_strings_xml-rus.xml
+++ b/src/Module.Server/ModuleData/Languages/RU/std_native_strings_xml-rus.xml
@@ -39,6 +39,9 @@
     <string id="bp8JJZpG" text="·   Защищайте графа от волн врагов!{newline}·   Получайте награды за защиту!{newline}·   Улучшайте своего персонажа на c-rpg.eu" />
     <string id="3uoZAXxh" text="Защита графа" />
 
+    <!-- Intermission -->
+    <string id="OZYLgnQq" text="Пожалуйста, подождите:" />
+    
     <!-- Scoreboard -->
     <string id="fBDiQBrC" text="Жизнь" />
 


### PR DESCRIPTION
Removes all map tiles from voting screen. `MapPoolComponent.cs` already casts 1 vote on the next map in rotation, so the winning map will be the one in rotation.