### PR TITLE
fix: dtv null check for mount to kill

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -262,15 +262,17 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _currentWave = -1;
         SpawningBehavior.RequestSpawnSessionForRoundStart(firstRound: _currentRound == 0);
         SendDataToPeers(new CrpgDtvRoundStartMessage { Round = _currentRound });
-
-        for (int i = _mountsToKill.Count - 1; i >= 0; i--) // kill mounts marked for death
+        if (_mountsToKill.Count > 0)
         {
-            if (_mountsToKill[i].RiderAgent == null)
+            for (int i = _mountsToKill.Count - 1; i >= 0; i--) // kill mounts marked for death
             {
-                DamageHelper.DamageAgent(_mountsToKill[i], 500);
-            }
+                if (_mountsToKill[i] != null && _mountsToKill[i].RiderAgent == null)
+                {
+                    DamageHelper.DamageAgent(_mountsToKill[i], 500);
+                }
 
-            _mountsToKill.Remove(_mountsToKill[i]);
+                _mountsToKill.Remove(_mountsToKill[i]);
+            }
         }
 
         foreach (var mount in Mission.MountsWithoutRiders) // force mounts to flee and mark them to die next round


### PR DESCRIPTION
Null reference exception when calling `Crpg.Module.Common.DamageHelper.DamageAgent()` from `CrpgDtvServer.cs`

```Application: DedicatedCustomServer.Starter.exe
CoreCLR Version: 6.0.1222.56807
.NET Version: 6.0.12
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException: Object reference not set to an instance of an object.
   at TaleWorlds.MountAndBlade.Agent.GetProtectorArmorMaterialOfBone(SByte boneIndex)
   at TaleWorlds.MountAndBlade.Agent.HandleBlow(Blow& b, AttackCollisionData& collisionData)
   at TaleWorlds.MountAndBlade.Agent.RegisterBlow(Blow blow, AttackCollisionData& collisionData)
   at Crpg.Module.Common.DamageHelper.DamageAgent(Agent agent, Int32 damage) in C:\Users\namidaka\source\repos\crpg\src\Module.Server\Common\DamageHelper.cs:line 74
   at Crpg.Module.Modes.Dtv.CrpgDtvServer.StartNextRound() in C:\Users\namidaka\source\repos\crpg\src\Module.Server\Modes\Dtv\CrpgDtvServer.cs:line 270
   at Crpg.Module.Modes.Dtv.CrpgDtvServer.CheckForWaveEnd() in C:\Users\namidaka\source\repos\crpg\src\Module.Server\Modes\Dtv\CrpgDtvServer.cs:line 300
   at TaleWorlds.MountAndBlade.Mission.OnTick(Single dt, Single realDt, Boolean updateCamera, Boolean doAsyncAITick)
   at TaleWorlds.MountAndBlade.MissionState.TickMission(Single realDt)
   at TaleWorlds.MountAndBlade.MissionState.OnTick(Single realDt)
   at TaleWorlds.Core.Game.OnTick(Single dt)
   at TaleWorlds.Core.GameManagerBase.OnTick(Single dt)
   at TaleWorlds.MountAndBlade.Module.OnApplicationTick(Single dt)
   at TaleWorlds.DotNet.Managed.ApplicationTick(Single dt)