### PR TITLE
DTV: nerf Pirate round

### DIFF
--- a/src/Module.Server/ModuleData/dtv/dtv_characters.xml
+++ b/src/Module.Server/ModuleData/dtv/dtv_characters.xml
@@ -728,8 +728,8 @@
     <skills>
       <skill id="Strength" value="15" />
       <skill id="Agility" value="15" />
-      <skill id="IronFlesh" value="4" />
-      <skill id="PowerStrike" value="3" />
+      <skill id="IronFlesh" value="2" />
+      <skill id="PowerStrike" value="2" />
       <skill id="PowerDraw" value="0" />
       <skill id="PowerThrow" value="0" />
       <skill id="Athletics" value="90" />
@@ -775,8 +775,8 @@
     <skills>
       <skill id="Strength" value="15" />
       <skill id="Agility" value="15" />
-      <skill id="IronFlesh" value="5" />
-      <skill id="PowerStrike" value="4" />
+      <skill id="IronFlesh" value="2" />
+      <skill id="PowerStrike" value="2" />
       <skill id="PowerDraw" value="0" />
       <skill id="PowerThrow" value="2" />
       <skill id="Athletics" value="90" />
@@ -821,7 +821,7 @@
     <skills>
       <skill id="Strength" value="18" />
       <skill id="Agility" value="15" />
-      <skill id="IronFlesh" value="4" />
+      <skill id="IronFlesh" value="3" />
       <skill id="PowerStrike" value="3" />
       <skill id="PowerDraw" value="0" />
       <skill id="PowerThrow" value="0" />
@@ -867,7 +867,7 @@
     <skills>
       <skill id="Strength" value="18" />
       <skill id="Agility" value="15" />
-      <skill id="IronFlesh" value="4" />
+      <skill id="IronFlesh" value="3" />
       <skill id="PowerStrike" value="3" />
       <skill id="PowerDraw" value="0" />
       <skill id="PowerThrow" value="0" />
@@ -913,8 +913,8 @@
     <skills>
       <skill id="Strength" value="18" />
       <skill id="Agility" value="21" />
-      <skill id="IronFlesh" value="6" />
-      <skill id="PowerStrike" value="5" />
+      <skill id="IronFlesh" value="2" />
+      <skill id="PowerStrike" value="6" />
       <skill id="PowerDraw" value="0" />
       <skill id="PowerThrow" value="0" />
       <skill id="Athletics" value="95" />

--- a/src/Module.Server/ModuleData/dtv/dtv_data.xml
+++ b/src/Module.Server/ModuleData/dtv/dtv_data.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <DtvData>
   
   <Round reward="55">
@@ -70,24 +70,23 @@
 
   <Round reward="190">
     <Wave>
-      <Group classDivisionId="crpg_dtv_pirate_swabbie" count="1.5" />
-      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="1.5" />
+      <Group classDivisionId="crpg_dtv_pirate_swabbie" count="1.0" />
+      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="1.0" />
       <Group classDivisionId="crpg_dtv_pirate_lieutenant" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_pirate_swabbie" count="0.5" />
-      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="0.5" />
-      <Group classDivisionId="crpg_dtv_pirate_male" count="1.0" />
-      <Group classDivisionId="crpg_dtv_pirate_female" count="0.5" />
+      <Group classDivisionId="crpg_dtv_pirate_swabbie" count="0.3" />
+      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="0.2" />
+      <Group classDivisionId="crpg_dtv_pirate_male" count="0.7" />
+      <Group classDivisionId="crpg_dtv_pirate_female" count="0.3" />
       <Group classDivisionId="crpg_dtv_pirate_swashbuckler" count="0.5" />
       <Group classDivisionId="crpg_dtv_pirate_lieutenant" />
     </Wave>
     <Wave>
-      <Group classDivisionId="crpg_dtv_pirate_swabbie" count="0.5" />
-      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="1.0" />
-      <Group classDivisionId="crpg_dtv_pirate_male" count="1.0" />
-      <Group classDivisionId="crpg_dtv_pirate_female" count="0.5" />
-      <Group classDivisionId="crpg_dtv_pirate_swashbuckler" count="1.0" />
+      <Group classDivisionId="crpg_dtv_pirate_deckhand" count="0.2" />
+      <Group classDivisionId="crpg_dtv_pirate_male" count="0.7" />
+      <Group classDivisionId="crpg_dtv_pirate_female" count="0.6" />
+      <Group classDivisionId="crpg_dtv_pirate_swashbuckler" count="0.5" />
       <Group classDivisionId="crpg_dtv_pirate_boss" />
     </Wave>
   </Round>


### PR DESCRIPTION
Pirate round was slightly overtuned. Lowered their stats and spawnrate to be more in line with the rest.