### PR TITLE
mod: increase ranged damage vs dtv bots

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -61,6 +61,12 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                 case WeaponClass.Arrow:
                     finalDamage *= 1.5f;
                     break;
+                case WeaponClass.Javelin:
+                case WeaponClass.ThrowingAxe:
+                case WeaponClass.ThrowingKnife:
+                case WeaponClass.Stone:
+                    finalDamage *= 2.0f;
+                    break;
             }
         }
 

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -51,6 +51,19 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             return 0f;
         }
 
+        if (IsPlayerCharacterAttackingDtvBot(attackInformation))
+        {
+            switch (weapon.CurrentUsageItem.WeaponClass)
+            {
+                case WeaponClass.Bolt:
+                    finalDamage *= 2.5f;
+                    break;
+                case WeaponClass.Arrow:
+                    finalDamage *= 1.5f;
+                    break;
+            }
+        }
+
         if (weapon.IsEmpty)
         {
             // Increase fist damage with strength and glove armor.
@@ -382,6 +395,20 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                 : false;
 
             return isVictimTheVipBot;
+        }
+
+        return false;
+    }
+
+    private bool IsPlayerCharacterAttackingDtvBot(AttackInformation attackInformation)
+    {
+        if (attackInformation.AttackerAgentOrigin is CrpgBattleAgentOrigin)
+        {
+            bool isVictimDtvBot = attackInformation.VictimAgentCharacter != null
+                ? attackInformation.VictimAgentCharacter.StringId.StartsWith("crpg_dtv_")
+                : false;
+
+            return isVictimDtvBot;
         }
 
         return false;


### PR DESCRIPTION
Increase ranged damage vs. dtv bots:
- Crossbow 2.5x
- Bow 1.5x
- Throwing weapons 2.0x