### PR TITLE
webui: click outside of clan member modal to close

### DIFF
--- a/src/WebUI/src/composables/use-modal-count.spec.ts
+++ b/src/WebUI/src/composables/use-modal-count.spec.ts
@@ -12,5 +12,5 @@ it('increase counter on call', () => {
   decrease();
   decrease();
 
-  expect(counter.value).toBe(-1);
+  expect(counter.value).toBe(0);
 });

--- a/src/WebUI/src/pages/clans/[id]/index.vue
+++ b/src/WebUI/src/pages/clans/[id]/index.vue
@@ -369,7 +369,6 @@ await fetchPageData(clanId.value);
 
     <Modal
       :shown="clanMemberDetailModal"
-      :autoHide="false"
       data-aq-clan-member-detail-modal
       @apply-hide="selectedCLanMemberId = null"
       @hide="clanMemberDetailModal = false"


### PR DESCRIPTION
Proposed fix to #36 

In the current situation the [autoHide](https://floating-vue.starpad.dev/api/#autohide) prop is overridden for the clan member detail modal and set to `false`. This makes it so that closing the modal by clicking outside it is disabled. Removing this prop reverts back to the default behaviour where the modal can be closed by clicking outside of it.

Also changed the unit test for `use-modal-count` since it was failing. Seems like a guard statement was added to the modal counter that wasn't reflected in the unit test yet.