### PR TITLE
Mod : Remove verbose messages from Admin commands

### DIFF
--- a/src/Module.Server/Common/ChatCommands/Admin/BanCommand.cs
+++ b/src/Module.Server/Common/ChatCommands/Admin/BanCommand.cs
@@ -68,7 +68,6 @@ internal class BanCommand : AdminCommand
 
         string durationStr = FormatTimeSpan(duration);
         ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorFatal, $"You banned {targetPeer.UserName} for {durationStr}.");
-        ChatComponent.ServerSendServerMessageToEveryone(ColorFatal, $"{targetPeer.UserName} was banned by {fromPeer.UserName} for {durationStr}. Reason: {reason}");
 
         KickHelper.Kick(targetPeer, DisconnectType.BannedByPoll, "banned");
     }

--- a/src/Module.Server/Common/ChatCommands/Admin/KickCommand.cs
+++ b/src/Module.Server/Common/ChatCommands/Admin/KickCommand.cs
@@ -47,7 +47,6 @@ internal class KickCommand : AdminCommand
         }
 
         ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorFatal, $"You have kicked {targetPeer.UserName}.");
-        ChatComponent.ServerSendServerMessageToEveryone(ColorFatal, $"{targetPeer.UserName} was kicked by {fromPeer.UserName}.{(reason != null ? $" Reason: {reason}" : string.Empty)}");
 
         KickHelper.Kick(targetPeer, DisconnectType.KickedByHost);
     }


### PR DESCRIPTION
Change to make Ban & Kick non-verbose and stay between the Moderator and the user it was actioned against.

Currently ban and kick are both verbose commands in that they are announced to the server; this often goes against the grain in that it results in a peanut gallery of people going after the staff member who initiated the moderative action. This change serves to fix that.
