### PR TITLE
mod: Lower Shield Forcefield

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -41,7 +41,7 @@
   "damageFactorForPowerThrow": 0.1,
   "handlingFactorForWeaponMaster":  [0.7, 0.75, 0.8, 0.85, 0.95, 1.05, 1.20, 1.35, 1.45, 1.5, 1.55, 1.65, 1.7, 1.75],
   "durabilityFactorForShieldRecursiveCoefs": [1.0, 0.4, 0.1],
-  "infantryCoverageFactorForShieldCoef": 0.25,
+  "infantryCoverageFactorForShieldCoef": 0.20,
   "cavalryCoverageFactorForShieldCoef": 0.02,
   "mountedRangedSkillInaccuracy": [0.1, 0.15, 0.228, 0.334, 0.468, 0.63, 0.82, 1.038],
   "shieldDefendStunMultiplierForSkillRecursiveCoefs": [0.625, 0.18, 0.07],


### PR DESCRIPTION
Lower the shield coverage factor for infantry


This places the InfantryCoverageFactorForShieldCoef halfway between what it was before the buff and after, being done because 2-3 shield skill produces a noticeably larger forcefield than it should really have. This change will put it back into a normal space again.

Taken from: https://github.com/namidaka/itembalancing/pull/447 and moved to correct repo