### PR TITLE
webUI: Fix Steam Logon button

### DIFF
--- a/src/WebUI/locales/cn.yml
+++ b/src/WebUI/locales/cn.yml
@@ -4,10 +4,11 @@ locale:
   cn: 中文
 
 platform:
-  Steam: Steam Workshop
+  Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
-
+  SteamWorkshop: Steam Workshop
+  
 installation:
   title: 安装
   common:

--- a/src/WebUI/locales/cn.yml
+++ b/src/WebUI/locales/cn.yml
@@ -7,7 +7,6 @@ platform:
   Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
-  SteamWorkshop: Steam Workshop
   
 installation:
   title: 安装

--- a/src/WebUI/locales/en.yml
+++ b/src/WebUI/locales/en.yml
@@ -7,7 +7,6 @@ platform:
   Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
-  SteamWorkshop: Steam Workshop
 
 installation:
   title: Installation

--- a/src/WebUI/locales/en.yml
+++ b/src/WebUI/locales/en.yml
@@ -4,9 +4,10 @@ locale:
   cn: 中文
 
 platform:
-  Steam: Steam Workshop
+  Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
+  SteamWorkshop: Steam Workshop
 
 installation:
   title: Installation

--- a/src/WebUI/locales/ru.yml
+++ b/src/WebUI/locales/ru.yml
@@ -7,7 +7,6 @@ platform:
   Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
-  SteamWorkshop: Steam Workshop
   
 installation:
   title: Установка

--- a/src/WebUI/locales/ru.yml
+++ b/src/WebUI/locales/ru.yml
@@ -4,10 +4,11 @@ locale:
   cn: 中文
 
 platform:
-  Steam: Steam Workshop
+  Steam: Steam
   EpicGames: Epic Games
   Microsoft: Xbox
-
+  SteamWorkshop: Steam Workshop
+  
 installation:
   title: Установка
   common:

--- a/src/WebUI/src/components/app/InstallationGuide.vue
+++ b/src/WebUI/src/components/app/InstallationGuide.vue
@@ -66,7 +66,7 @@ watch(
           </OTabItem>
 
           <OTabItem
-            :label="('Steam Workshop')"
+            label="Steam Workshop"
             :icon="platformToIcon[Platform.Steam]"
             :value="PossibleValues.Steam"
           >

--- a/src/WebUI/src/components/app/InstallationGuide.vue
+++ b/src/WebUI/src/components/app/InstallationGuide.vue
@@ -66,7 +66,7 @@ watch(
           </OTabItem>
 
           <OTabItem
-            :label="$t(`platform.${Platform.Steam}`)"
+            :label="$t('platform.SteamWorkshop')"
             :icon="platformToIcon[Platform.Steam]"
             :value="PossibleValues.Steam"
           >

--- a/src/WebUI/src/components/app/InstallationGuide.vue
+++ b/src/WebUI/src/components/app/InstallationGuide.vue
@@ -66,7 +66,7 @@ watch(
           </OTabItem>
 
           <OTabItem
-            :label="$t('platform.SteamWorkshop')"
+            :label="('Steam Workshop')"
             :icon="platformToIcon[Platform.Steam]"
             :value="PossibleValues.Steam"
           >

--- a/src/WebUI/src/types/vite-components.d.ts
+++ b/src/WebUI/src/types/vite-components.d.ts
@@ -10,7 +10,6 @@ declare module 'vue' {
     ActivityLogItem: typeof import('./../components/moderator/ActivityLogItem.vue')['default']
     Bg: typeof import('./../components/app/Bg.vue')['default']
     CharacterCreateModal: typeof import('./../components/character/CharacterCreateModal.vue')['default']
-    CharacterEarningChart: typeof import('./../components/character/CharacterEarningChart.vue')['default']
     CharacterEditForm: typeof import('./../components/character/CharacterEditForm.vue')['default']
     CharacterInventoryDoll: typeof import('./../components/character/inventory/CharacterInventoryDoll.vue')['default']
     CharacterInventoryDollSlot: typeof import('./../components/character/inventory/CharacterInventoryDollSlot.vue')['default']

--- a/src/WebUI/src/types/vite-components.d.ts
+++ b/src/WebUI/src/types/vite-components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     ActivityLogItem: typeof import('./../components/moderator/ActivityLogItem.vue')['default']
     Bg: typeof import('./../components/app/Bg.vue')['default']
     CharacterCreateModal: typeof import('./../components/character/CharacterCreateModal.vue')['default']
+    CharacterEarningChart: typeof import('./../components/character/CharacterEarningChart.vue')['default']
     CharacterEditForm: typeof import('./../components/character/CharacterEditForm.vue')['default']
     CharacterInventoryDoll: typeof import('./../components/character/inventory/CharacterInventoryDoll.vue')['default']
     CharacterInventoryDollSlot: typeof import('./../components/character/inventory/CharacterInventoryDollSlot.vue')['default']


### PR DESCRIPTION
Fixing mistake applied to logon button that resulted in it being named 'Steam Workshop' as opposed to 'Steam'

Set en.yml/cn.yml/ru.yml platform back to 'Steam'

Changed Tab inside InstallationGuide.vue to static label