### PR TITLE
mod: fix conquest spectator bug

### DIFF
--- a/src/Module.Server/Common/TeamSelect/CrpgTeamSelectServerComponent.cs
+++ b/src/Module.Server/Common/TeamSelect/CrpgTeamSelectServerComponent.cs
@@ -117,6 +117,13 @@ internal class CrpgTeamSelectServerComponent : MultiplayerTeamSelectComponent
                     ChangeTeamServer(peer, teamBeforeSpectator);
                     _playerTeamsBeforeJoiningSpectator.Remove(peer.VirtualPlayer.Id);
                 }
+                else if (missionPeer.Team.TeamIndex == Mission.SpectatorTeam.TeamIndex)
+                {
+                    // If the player's original team was spectator, auto-assign their team so that they can play
+                    // the round. They will be considered for balancing at the end of the round.
+                    AutoAssignTeam(peer);
+                    _playersWaitingForTeam.Add(peer.VirtualPlayer.Id);
+                }
                 else
                 {
                     _playersWaitingForTeam.Add(peer.VirtualPlayer.Id);


### PR DESCRIPTION
Auto assigns the player team if their first team was spectator. This allows players to play in rounds before a balance event (which never occurs in conquest after warmup).

Players who have been auto-assigned are then added to the `_playersWaitingForTeam` HashSet so they can be considered for balancing in Battle.