### PR TITLE
mod: low lvl handling buff

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -39,7 +39,7 @@
   "damageFactorForPowerStrike": 0.08,
   "damageFactorForPowerDraw": 0.14,
   "damageFactorForPowerThrow": 0.1,
-  "handlingFactorForWeaponMaster":  [0.7, 0.75, 0.8, 0.85, 0.95, 1.05, 1.20, 1.35, 1.45, 1.5, 1.55, 1.65, 1.7, 1.75],
+  "handlingFactorForWeaponMaster":  [0.7, 0.75, 0.8, 0.85, 0.95, 1.10, 1.25, 1.35, 1.45, 1.5, 1.55, 1.65, 1.7, 1.75],
   "durabilityFactorForShieldRecursiveCoefs": [1.0, 0.4, 0.1],
   "infantryCoverageFactorForShieldCoef": 0.20,
   "cavalryCoverageFactorForShieldCoef": 0.02,


### PR DESCRIPTION
Increase handling @ lvl 5 & 6 Weapon Mastery

A slight increase to handling for Weapon Mastery at levels 5 & 6 to address feelings of slowness on weapons - Lvl 5 & 6 is the typical range of handling level most low levels will experience as this is what most common place builds end up with hence the importance for good feeling.