### PR TITLE
mod: keep value when generating stats for fixed price items

### DIFF
--- a/src/Module.Client/DataExport/ItemExporter.cs
+++ b/src/Module.Client/DataExport/ItemExporter.cs
@@ -984,12 +984,6 @@ internal class ItemExporter : IDataExporter
             {
                 int heirloomLevel = IdToHeirloomLevel(node1.Attributes!["id"].Value);
                 string baseId = node1.Attributes!["id"].Value.Remove(node1.Attributes!["id"].Value.Length - 2);
-                // Remove the price attribute so it is recomputed using our model.
-                var valueAttr = node1.Attributes["value"];
-                if (valueAttr != null)
-                {
-                    node1.Attributes.Remove(valueAttr);
-                }
 
                 var nonHeirloomNode = baseItem[baseId];
                 var type = (ItemObject.ItemTypeEnum)Enum.Parse(typeof(ItemObject.ItemTypeEnum), node1.Attributes!["Type"].Value);


### PR DESCRIPTION
@Meowkov reported issues with the exporter removing the 'value' field in weapons.xml when setting smokebomb price manually. This change removes that functionality, so crafters can set price overrides without it impacting the xml.