### PR TITLE
mod: polearm bvS Reduction

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -160,6 +160,10 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                         case WeaponClass.TwoHandedPolearm:
                             finalDamage *= 1.5f;
                             break;
+
+                        default:
+                            finalDamage *= 1.5f;
+                            break;
                     }
                 }
             }

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -120,7 +120,7 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                     // it is the same logic as arrows not dealing a lot of damage to horse but spears dealing extra damage to horses
                     // As we want archer to fear cavs and cavs to fear spears, we want swords to fear shielders and shielders to fear axes.
 
-                    finalDamage *= axeClass.Contains(weapon.CurrentUsageItem.WeaponClass) ? 1.5f : 2.0f;
+                    finalDamage *= axeClass.Contains(weapon.CurrentUsageItem.WeaponClass) ? 2.0f : 1.5f;
                 }
             }
         }

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -44,6 +44,11 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             WeaponClass.OneHandedSword,
             WeaponClass.TwoHandedSword,
         };
+        List<WeaponClass> axeClass = new()
+        {
+            WeaponClass.OneHandedAxe,
+            WeaponClass.TwoHandedAxe,
+        };
         float finalDamage = base.CalculateDamage(attackInformation, collisionData, weapon, baseDamage);
 
         if (IsPlayerCharacterAttackingVipBot(attackInformation))
@@ -115,56 +120,7 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                     // it is the same logic as arrows not dealing a lot of damage to horse but spears dealing extra damage to horses
                     // As we want archer to fear cavs and cavs to fear spears, we want swords to fear shielders and shielders to fear axes.
 
-                    switch (weapon.CurrentUsageItem.WeaponClass)
-                    {
-                        case WeaponClass.Dagger:
-                            finalDamage *= 1.5f;
-                            break;
-
-                        case WeaponClass.Mace:
-                            finalDamage *= 1.5f;
-                            break;
-
-                        case WeaponClass.TwoHandedMace:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.OneHandedSword:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.TwoHandedSword:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.OneHandedAxe:
-                            finalDamage *= 2.0f;
-                            break;
-                            
-                        case WeaponClass.TwoHandedAxe:
-                            finalDamage *= 2.0f;
-                            break;
-                            
-                        case WeaponClass.Pick:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.LowGripPolearm:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.OneHandedPolearm:
-                            finalDamage *= 1.5f;
-                            break;
-                            
-                        case WeaponClass.TwoHandedPolearm:
-                            finalDamage *= 1.5f;
-                            break;
-
-                        default:
-                            finalDamage *= 1.5f;
-                            break;
-                    }
+                    finalDamage *= axeClass.Contains(weapon.CurrentUsageItem.WeaponClass) ? 1.5f : 2.0f;
                 }
             }
         }

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -111,11 +111,56 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                 if (weapon.CurrentUsageItem.WeaponFlags.HasAnyFlag(WeaponFlags.BonusAgainstShield))
                 {
                     // this bonus is on top of the native x2 in MissionCombatMechanicsHelper
-                    // so the final bonus is 4.0 for axes and 3 for swords. We do this instead of nerfing the impact of shield skill so shield can stay virtually unbreakable against sword.
+                    // so the final bonus is 4.0 for one- and two- handed axes and 3.0 for everything else. We do this instead of nerfing the impact of shield skill so shield can stay virtually unbreakable against sword.
                     // it is the same logic as arrows not dealing a lot of damage to horse but spears dealing extra damage to horses
                     // As we want archer to fear cavs and cavs to fear spears, we want swords to fear shielders and shielders to fear axes.
 
-                    finalDamage *= swordClass.Contains(weapon.CurrentUsageItem.WeaponClass) ? 1.5f : 2.0f;
+                    switch (weapon.CurrentUsageItem.WeaponClass)
+                    {
+                        case WeaponClass.Dagger:
+                            finalDamage *= 1.5f;
+                            break;
+
+                        case WeaponClass.Mace:
+                            finalDamage *= 1.5f;
+                            break;
+
+                        case WeaponClass.TwoHandedMace:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.OneHandedSword:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.TwoHandedSword:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.OneHandedAxe:
+                            finalDamage *= 2.0f;
+                            break;
+                            
+                        case WeaponClass.TwoHandedAxe:
+                            finalDamage *= 2.0f;
+                            break;
+                            
+                        case WeaponClass.Pick:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.LowGripPolearm:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.OneHandedPolearm:
+                            finalDamage *= 1.5f;
+                            break;
+                            
+                        case WeaponClass.TwoHandedPolearm:
+                            finalDamage *= 1.5f;
+                            break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reduced polearm BvS damage by 25%.

Changed the final BvS value to be 4.0 for one- and two-handed axes (based on a new weapon class containing only those two), and 3.0 for everything else. Weapons that are not axes do not have a stun-user-on-hit-effect (aka cleave) which makes them less attractive to fight with. Previously this was off set by having axes be the premier BvS weapon over swords. With the introduction of more BvS polearms, axes were further pushed away from being an attractive weapon class, as the code previously only gave weapon class swords a lower BvS value. Now axes receive a higher BvS value, and everything else (including the polearms mentioned) receive the lower value.

This reduces the BvS damage of:

All polearms with BvS
The 5 one-handed maces with BvS
The 2 two-handed maces with BvS